### PR TITLE
CODE RUB: Use Exception instead of Xeption type in exceptions' constructors

### DIFF
--- a/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientDependencyException.cs
+++ b/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientDependencyException.cs
@@ -2,15 +2,15 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Clients.Completions.Exceptions
 {
     internal class CompletionClientDependencyException : Xeption
     {
-        public CompletionClientDependencyException(Xeption innerException)
-            : base(message: "Completion dependency error occurred, contact support.",
-                  innerException)
+        public CompletionClientDependencyException(Exception innerException)
+            : base(message: "Completion dependency error occurred, contact support.", innerException)
         { }
     }
 }

--- a/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientServiceException.cs
+++ b/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientServiceException.cs
@@ -2,15 +2,15 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Clients.Completions.Exceptions
 {
     internal class CompletionClientServiceException : Xeption
     {
-        public CompletionClientServiceException(Xeption innerException)
-            : base(message: "Completion client service error occurred, contact support.",
-                  innerException)
+        public CompletionClientServiceException(Exception innerException)
+            : base(message: "Completion client service error occurred, contact support.", innerException)
         { }
     }
 }

--- a/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientValidationException.cs
+++ b/Standard.AI.OpenAI/Models/Clients/Completions/Exceptions/CompletionClientValidationException.cs
@@ -2,15 +2,15 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Clients.Completions.Exceptions
 {
     internal class CompletionClientValidationException : Xeption
     {
-        public CompletionClientValidationException(Xeption innerException)
-            : base(message: "Completion client validation error occurred, fix errors and try again.",
-                   innerException)
+        public CompletionClientValidationException(Exception innerException)
+            : base(message: "Completion client validation error occurred, fix errors and try again.", innerException)
         { }
     }
 }

--- a/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionDependencyValidationException.cs
+++ b/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionDependencyValidationException.cs
@@ -2,13 +2,14 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Services.Foundations.Completions.Exceptions
 {
-    internal class CompletionDependencyValidationException : Xeption
+    public class CompletionDependencyValidationException : Xeption
     {
-        public CompletionDependencyValidationException(Xeption innerException)
+        public CompletionDependencyValidationException(Exception innerException)
             : base(message: "Completion dependency validation error occurred. Fix errors and try again.", innerException)
         { }
     }

--- a/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionServiceException.cs
+++ b/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionServiceException.cs
@@ -2,13 +2,14 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Services.Foundations.Completions.Exceptions
 {
-    internal class CompletionServiceException : Xeption
+    public class CompletionServiceException : Xeption
     {
-        public CompletionServiceException(Xeption innerException)
+        public CompletionServiceException(Exception innerException)
             : base(message: "Completion service error occurred contact support.", innerException)
         { }
     }

--- a/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionValidationException.cs
+++ b/Standard.AI.OpenAI/Models/Services/Foundations/Completions/Exceptions/CompletionValidationException.cs
@@ -2,13 +2,14 @@
 // Copyright (c) Coalition of the Good-Hearted Engineers 
 // ---------------------------------------------------------------
 
+using System;
 using Xeptions;
 
 namespace Standard.AI.OpenAI.Models.Services.Foundations.Completions.Exceptions
 {
     public class CompletionValidationException : Xeption
     {
-        public CompletionValidationException(Xeption innerException)
+        public CompletionValidationException(Exception innerException)
             : base(message: "Completion validation error occurred, try again.", innerException)
         { }
     }


### PR DESCRIPTION
I'm watching video number `005`. Hassan mentions that the exceptions should receive `Exception` type because it could be anything, since it's coming from the outside. 

If something is wrong, i'm all ears!