### PR TITLE
CODE RUB: Change the interface of IOpenAIClient to only expose the get.

### DIFF
--- a/Standard.AI.OpenAI/Clients/OpenAIs/IOpenAIClient.cs
+++ b/Standard.AI.OpenAI/Clients/OpenAIs/IOpenAIClient.cs
@@ -8,6 +8,6 @@ namespace Standard.AI.OpenAI.Clients.OpenAIs
 {
     public interface IOpenAIClient
     {
-        ICompletionsClient Completions { get; set; }
+        ICompletionsClient Completions { get; }
     }
 }

--- a/Standard.AI.OpenAI/Clients/OpenAIs/OpenAIClient.cs
+++ b/Standard.AI.OpenAI/Clients/OpenAIs/OpenAIClient.cs
@@ -19,7 +19,7 @@ namespace Standard.AI.OpenAI.Clients.OpenAIs
             InitializeClients(serviceProvider);
         }
 
-        public ICompletionsClient Completions { get; set; }
+        public ICompletionsClient Completions { get; private set; }
 
         private void InitializeClients(IServiceProvider serviceProvider) =>
             Completions = serviceProvider.GetRequiredService<ICompletionsClient>();


### PR DESCRIPTION
A small change to make the setter private  `public ICompletionsClient Completions { get; private set; }`

We should not allow this property to be overridden post initialization.  

If another implementation of `ICompletionsClient` is required, it should be initialised through its own exposer and if variations can then be surfaced through SPAL implementation.

(and if another concrete implementation ever exist in this library, we can use config to initialise the desired one)