### PR TITLE
DOCUMENTATION: Readme Cleanup Add Nuget Refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,3 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
-
-[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
-
-[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)
-
-[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/o8ZdFcScOKU?feature=share)
-
-[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/OvU6Tate4iI?feature=share)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Standard.AI.OpenAI
 
-![](https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png)
+<div align=center>
+	<img width="300" src="https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png" />
+</div>
 
+<br />
 
 [![.NET](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml/badge.svg)](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml)
-[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
 [![The Standard - COMPLIANT](https://img.shields.io/badge/The_Standard-COMPLIANT-2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 
@@ -23,12 +25,6 @@ In order to use this library there are prerequists that you must complete before
 You must create an OpenAI account with the following link:
 https://platform.openai.com/signup
 
-### Nuget Package 
-Install the Standard.AI.OpenAI library in your project.
-Use the method best suited for your development preference listed at the Nuget Link above or below.
-
-[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
-
 ### API Keys
 Once you've created an OpenAI account. Now, go ahead and generate an API key from the following link:
 https://platform.openai.com/account/api-keys
@@ -36,7 +32,10 @@ https://platform.openai.com/account/api-keys
 ### Hello, World!
 Once you've completed the aforementioned steps, let's write our very first program with Standard.AI.OpenAI as follows:
 
-### Program.cs
+#### Standard.AI.OpenAI Nuget
+Find our nuget package.
+
+#### Program.cs
 The following example demonstrate how you can write your first Completions program.
 
 ```csharp
@@ -78,7 +77,7 @@ If you want to contribute to this project please review the following documents:
 If you have a question make sure you either open an issue or join our [The Standard Community](https://discord.com/invite/vdPZ7hS52X) discord server.
 
 ## Live-Sessions
-Our live-sessions are scheduled on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to be able to join us.
+Our live-sessions are schedules on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to to be able to join us.
 
 We broadcast on multiple platforms:
 
@@ -114,7 +113,3 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
-
-[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
-
-[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 	<img width="300" src="https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png" />
 </div>
 
-</br>
+<br />
 
 [![.NET](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml/badge.svg)](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml)
-[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
 [![The Standard - COMPLIANT](https://img.shields.io/badge/The_Standard-COMPLIANT-2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 
@@ -26,12 +25,6 @@ In order to use this library there are prerequists that you must complete before
 You must create an OpenAI account with the following link:
 https://platform.openai.com/signup
 
-### Nuget Package 
-Install the Standard.AI.OpenAI library in your project.
-Use the method best suited for your development preference listed at the Nuget Link above or below.
-
-[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
-
 ### API Keys
 Once you've created an OpenAI account. Now, go ahead and generate an API key from the following link:
 https://platform.openai.com/account/api-keys
@@ -39,7 +32,10 @@ https://platform.openai.com/account/api-keys
 ### Hello, World!
 Once you've completed the aforementioned steps, let's write our very first program with Standard.AI.OpenAI as follows:
 
-### Program.cs
+#### Standard.AI.OpenAI Nuget
+Find our nuget package.
+
+#### Program.cs
 The following example demonstrate how you can write your first Completions program.
 
 ```csharp
@@ -81,7 +77,7 @@ If you want to contribute to this project please review the following documents:
 If you have a question make sure you either open an issue or join our [The Standard Community](https://discord.com/invite/vdPZ7hS52X) discord server.
 
 ## Live-Sessions
-Our live-sessions are scheduled on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to be able to join us.
+Our live-sessions are schedules on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to to be able to join us.
 
 We broadcast on multiple platforms:
 
@@ -117,9 +113,3 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
-
-[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
-
-[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)
-
-[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/o8ZdFcScOKU?feature=share)

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 <br />
 
 [![.NET](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml/badge.svg)](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml)
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
+![Nuget](https://img.shields.io/nuget/dt/Standard.AI.OpenAI?color=blue&label=Downloads)
 [![The Standard - COMPLIANT](https://img.shields.io/badge/The_Standard-COMPLIANT-2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 
@@ -25,6 +27,12 @@ In order to use this library there are prerequists that you must complete before
 You must create an OpenAI account with the following link:
 https://platform.openai.com/signup
 
+### Nuget Package 
+Install the Standard.AI.OpenAI library in your project.
+Use the method best suited for your development preference listed at the Nuget Link above or below.
+
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
+
 ### API Keys
 Once you've created an OpenAI account. Now, go ahead and generate an API key from the following link:
 https://platform.openai.com/account/api-keys
@@ -32,40 +40,50 @@ https://platform.openai.com/account/api-keys
 ### Hello, World!
 Once you've completed the aforementioned steps, let's write our very first program with Standard.AI.OpenAI as follows:
 
-#### Standard.AI.OpenAI Nuget
-Find our nuget package.
-
-#### Program.cs
+### Program.cs
 The following example demonstrate how you can write your first Completions program.
 
 ```csharp
-using OpenAI.NET.Clients.OpenAIs;
-using OpenAI.NET.Models.Configurations;
-using OpenAI.NET.Models.Services.Foundations.Completions;
+using System;
+using System.Threading.Tasks;
+using Standard.AI.OpenAI.Clients.OpenAIs;
+using Standard.AI.OpenAI.Models.Configurations;
+using Standard.AI.OpenAI.Models.Services.Foundations.Completions;
 
-var openAiApiConfigurations = new ApiConfigurations
+namespace ExampleOpenAIDotNet
 {
-    ApiKey = "YOUR_API_KEY_HERE",
-    OrganizationId = "YOUR_OPTIONAL_ORG_ID_HERE"
-};
-
-var openAiClient = new OpenAIClient(openAiApiConfigurations);
-
-var inputCompletion = new Completion
-{
-    Request = new CompletionRequest
+    internal class Program
     {
-        Prompt = new string[] { "Human: Hello!" },
+        static async Task Main(string[] args)
+        {
+            var openAIApiConfigurations = new ApiConfigurations
+            {
+                ApiKey = "YOUR_API_KEY_HERE",
+                OrganizationId = "YOUR_OPTIONAL_ORG_ID_HERE"
+            };
 
-        Model = "text-davinci-003"
+            var openAIClient = new OpenAIClient(openAIApiConfigurations);
+
+            var inputCompletion = new Completion
+            {
+                Request = new CompletionRequest
+                {
+                    Prompts = new string[] { "Human: Hello!" },
+
+                    Model = "text-davinci-003"
+                }
+            };
+
+            Completion resultCompletion =
+                await openAIClient.Completions.PromptCompletionAsync(
+                    inputCompletion);
+
+            Array.ForEach(
+                resultCompletion.Response.Choices, 
+                choice => Console.WriteLine(choice.Text));
+        }
     }
-};
-
-Completion resultCompletion =
-    await openAiClient.Completions.PromptCompletionAsync(
-        inputCompletion);
-
-Array.ForEach(resultCompletion.Response.Choices, choice => Console.WriteLine(choice.Text));
+}
 ```
 
 ## How to Contribute
@@ -77,7 +95,7 @@ If you want to contribute to this project please review the following documents:
 If you have a question make sure you either open an issue or join our [The Standard Community](https://discord.com/invite/vdPZ7hS52X) discord server.
 
 ## Live-Sessions
-Our live-sessions are schedules on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to to be able to join us.
+Our live-sessions are scheduled on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to be able to join us.
 
 We broadcast on multiple platforms:
 
@@ -113,3 +131,11 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
+
+[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
+
+[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)
+
+[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/o8ZdFcScOKU?feature=share)
+
+[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/OvU6Tate4iI?feature=share)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Standard.AI.OpenAI
 
-<div align=center>
-	<img width="300" src="https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png" />
-</div>
+![](https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png)
 
-<br />
 
 [![.NET](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml/badge.svg)](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml)
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
 [![The Standard - COMPLIANT](https://img.shields.io/badge/The_Standard-COMPLIANT-2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 
@@ -25,6 +23,12 @@ In order to use this library there are prerequists that you must complete before
 You must create an OpenAI account with the following link:
 https://platform.openai.com/signup
 
+### Nuget Package 
+Install the Standard.AI.OpenAI library in your project.
+Use the method best suited for your development preference listed at the Nuget Link above or below.
+
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
+
 ### API Keys
 Once you've created an OpenAI account. Now, go ahead and generate an API key from the following link:
 https://platform.openai.com/account/api-keys
@@ -32,10 +36,7 @@ https://platform.openai.com/account/api-keys
 ### Hello, World!
 Once you've completed the aforementioned steps, let's write our very first program with Standard.AI.OpenAI as follows:
 
-#### Standard.AI.OpenAI Nuget
-Find our nuget package.
-
-#### Program.cs
+### Program.cs
 The following example demonstrate how you can write your first Completions program.
 
 ```csharp
@@ -77,7 +78,7 @@ If you want to contribute to this project please review the following documents:
 If you have a question make sure you either open an issue or join our [The Standard Community](https://discord.com/invite/vdPZ7hS52X) discord server.
 
 ## Live-Sessions
-Our live-sessions are schedules on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to to be able to join us.
+Our live-sessions are scheduled on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to be able to join us.
 
 We broadcast on multiple platforms:
 
@@ -113,3 +114,7 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
+
+[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
+
+[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@
 	<img width="300" src="https://raw.githubusercontent.com/hassanhabib/OpenAI.NET/main/Standard.AI.OpenAI/artificial-intelligence.png" />
 </div>
 
-<br />
+</br>
 
 [![.NET](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml/badge.svg)](https://github.com/hassanhabib/OpenAI.NET/actions/workflows/dotnet.yml)
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
 [![The Standard - COMPLIANT](https://img.shields.io/badge/The_Standard-COMPLIANT-2ea44f)](https://github.com/hassanhabib/The-Standard)
 [![The Standard Community](https://img.shields.io/discord/934130100008538142?color=%237289da&label=The%20Standard%20Community&logo=Discord)](https://discord.gg/vdPZ7hS52X)
 
@@ -25,6 +26,12 @@ In order to use this library there are prerequists that you must complete before
 You must create an OpenAI account with the following link:
 https://platform.openai.com/signup
 
+### Nuget Package 
+Install the Standard.AI.OpenAI library in your project.
+Use the method best suited for your development preference listed at the Nuget Link above or below.
+
+[![Nuget](https://img.shields.io/nuget/v/Standard.AI.OpenAI?logo=nuget)](https://www.nuget.org/packages/Standard.AI.OpenAI)
+
 ### API Keys
 Once you've created an OpenAI account. Now, go ahead and generate an API key from the following link:
 https://platform.openai.com/account/api-keys
@@ -32,10 +39,7 @@ https://platform.openai.com/account/api-keys
 ### Hello, World!
 Once you've completed the aforementioned steps, let's write our very first program with Standard.AI.OpenAI as follows:
 
-#### Standard.AI.OpenAI Nuget
-Find our nuget package.
-
-#### Program.cs
+### Program.cs
 The following example demonstrate how you can write your first Completions program.
 
 ```csharp
@@ -77,7 +81,7 @@ If you want to contribute to this project please review the following documents:
 If you have a question make sure you either open an issue or join our [The Standard Community](https://discord.com/invite/vdPZ7hS52X) discord server.
 
 ## Live-Sessions
-Our live-sessions are schedules on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to to be able to join us.
+Our live-sessions are scheduled on [The Standard Calendar](https://tinyurl.com/the-standard-calendar) make sure you adjust the time to your city/timezone to be able to join us.
 
 We broadcast on multiple platforms:
 
@@ -113,3 +117,9 @@ Here's our live sessions to show you how this library was developed from scratch
 [OPENAI008: Acceptance & Integration Tests](https://www.youtube.com/live/86bfBmkUMFo?feature=share)
 
 [OPENAI009: Publishing Nuget Package](https://www.youtube.com/live/saU_5peAC-Y?feature=share)
+
+[OPENAI010: Developing Chat Integrations](https://www.youtube.com/live/YRLymNBSlqI?feature=share)
+
+[OPENAI011: Developing Chat Integrations](https://www.youtube.com/live/-6W_-5cKkfs?feature=share)
+
+[OPENAI012: Developing Chat Integrations](https://www.youtube.com/live/o8ZdFcScOKU?feature=share)


### PR DESCRIPTION
Closes #133

@hassanhabib @ElbekDeveloper 
Took some time today and reviewed Nuget packages that are using images. All seem to be using logo graphic some with an incorporated package name and others not. 
In conclusion Elbek is correct markdown syntax does not support centering, and all that found in nuget were left aligned. This PR incorporates the logo in markdown, nuget package links, and the latest videos.