### PR TITLE
MINOR FIX: Use ConfigurationBuilder in Integration Tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,8 +10,9 @@ jobs:
   build:
     runs-on: windows-latest
     env:
-      ApiKey: ${{ secrets.APIKEY }}
-      OrgId: ${{ secrets.ORGID }}
+      OpenAI__ApiKey: ${{ secrets.APIKEY }}
+      OpenAI__OrganizationId: ${{ secrets.ORGID }}
+      OpenAI__ApiUrl: https://api.openai.com/
     steps:
     - name: Pulling Code
       uses: actions/checkout@v2

--- a/Standard.AI.OpenAI.Infrastructure.Build/Program.cs
+++ b/Standard.AI.OpenAI.Infrastructure.Build/Program.cs
@@ -40,8 +40,9 @@ namespace Standard.AI.OpenAI.Infrastructure.Build
                     {
                         EnvironmentVariables = new Dictionary<string, string>
                         {
-                            { "ApiKey", "${{ secrets.APIKEY }}" },
-                            { "OrgId", "${{ secrets.ORGID }}" }
+                            { "OpenAI__ApiKey", "${{ secrets.APIKEY }}" },
+                            { "OpenAI__OrganizationId", "${{ secrets.ORGID }}" },
+                            { "OpenAI__ApiUrl", "https://api.openai.com/" }
                         },
 
                         RunsOn = BuildMachines.WindowsLatest,

--- a/Standard.AI.OpenAI.Tests.Integration/APIs/AIFiles/AIFilesTests.cs
+++ b/Standard.AI.OpenAI.Tests.Integration/APIs/AIFiles/AIFilesTests.cs
@@ -2,9 +2,9 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers 
 // ----------------------------------------------------------------------------------
 
-using System;
 using System.IO;
 using System.Text;
+using Microsoft.Extensions.Configuration;
 using Standard.AI.OpenAI.Clients.OpenAIs;
 using Standard.AI.OpenAI.Models.Configurations;
 
@@ -16,12 +16,10 @@ namespace Standard.AI.OpenAI.Tests.Integration.APIs.AIFiles
 
         public AIFilesTests()
         {
-            var openAIConfigurations = new OpenAIConfigurations
-            {
-                ApiKey = Environment.GetEnvironmentVariable("ApiKey"),
-                OrganizationId = Environment.GetEnvironmentVariable("OrgId"),
-                ApiUrl = "https://api.openai.com/"
-            };
+            IConfiguration config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+            OpenAIConfigurations openAIConfigurations =
+                config.GetSection(key: "OpenAI").Get<OpenAIConfigurations>();
 
             this.openAIClient = new OpenAIClient(openAIConfigurations);
         }

--- a/Standard.AI.OpenAI.Tests.Integration/APIs/AIModels/AIModelsApiTests.cs
+++ b/Standard.AI.OpenAI.Tests.Integration/APIs/AIModels/AIModelsApiTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers 
 // ----------------------------------------------------------------------------------
 
-using System;
+using Microsoft.Extensions.Configuration;
 using Standard.AI.OpenAI.Clients.OpenAIs;
 using Standard.AI.OpenAI.Models.Configurations;
 
@@ -14,12 +14,10 @@ namespace Standard.AI.OpenAI.Tests.Integration.APIs.AIModels
 
         public AIModelsApiTests()
         {
-            var openAIConfigurations = new OpenAIConfigurations
-            {
-                ApiKey = Environment.GetEnvironmentVariable("ApiKey"),
-                OrganizationId = Environment.GetEnvironmentVariable("OrgId"),
-                ApiUrl = "https://api.openai.com/"
-            };
+            IConfiguration config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+            OpenAIConfigurations openAIConfigurations =
+                config.GetSection(key: "OpenAI").Get<OpenAIConfigurations>();
 
             this.openAIClient = new OpenAIClient(openAIConfigurations);
         }

--- a/Standard.AI.OpenAI.Tests.Integration/APIs/ChatCompletions/ChatCompletionsApiTests.cs
+++ b/Standard.AI.OpenAI.Tests.Integration/APIs/ChatCompletions/ChatCompletionsApiTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers 
 // ----------------------------------------------------------------------------------
 
-using System;
+using Microsoft.Extensions.Configuration;
 using Standard.AI.OpenAI.Clients.OpenAIs;
 using Standard.AI.OpenAI.Models.Configurations;
 
@@ -14,12 +14,10 @@ namespace Standard.AI.OpenAI.Tests.Integration.APIs.ChatCompletions
 
         public ChatCompletionsApiTests()
         {
-            var openAIConfigurations = new OpenAIConfigurations
-            {
-                ApiKey = Environment.GetEnvironmentVariable("ApiKey"),
-                OrganizationId = Environment.GetEnvironmentVariable("OrgId"),
-                ApiUrl = "https://api.openai.com/"
-            };
+            IConfiguration config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+            OpenAIConfigurations openAIConfigurations =
+                config.GetSection(key: "OpenAI").Get<OpenAIConfigurations>();
 
             this.openAIClient = new OpenAIClient(openAIConfigurations);
         }

--- a/Standard.AI.OpenAI.Tests.Integration/APIs/Completions/CompletionsApiTests.cs
+++ b/Standard.AI.OpenAI.Tests.Integration/APIs/Completions/CompletionsApiTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers 
 // ----------------------------------------------------------------------------------
 
-using System;
+using Microsoft.Extensions.Configuration;
 using Standard.AI.OpenAI.Clients.OpenAIs;
 using Standard.AI.OpenAI.Models.Configurations;
 
@@ -14,12 +14,10 @@ namespace Standard.AI.OpenAI.Tests.Integration.APIs.Completions
 
         public CompletionsApiTests()
         {
-            var openAIConfigurations = new OpenAIConfigurations
-            {
-                ApiKey = Environment.GetEnvironmentVariable("ApiKey"),
-                OrganizationId = Environment.GetEnvironmentVariable("OrgId"),
-                ApiUrl = "https://api.openai.com/"
-            };
+            IConfiguration config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+            OpenAIConfigurations openAIConfigurations =
+                config.GetSection(key: "OpenAI").Get<OpenAIConfigurations>();
 
             this.openAIClient = new OpenAIClient(openAIConfigurations);
         }

--- a/Standard.AI.OpenAI.Tests.Integration/APIs/ImageGenerations/ImageGenerationApiTests.cs
+++ b/Standard.AI.OpenAI.Tests.Integration/APIs/ImageGenerations/ImageGenerationApiTests.cs
@@ -2,7 +2,7 @@
 // Copyright (c) The Standard Organization, a coalition of the Good-Hearted Engineers 
 // ----------------------------------------------------------------------------------
 
-using System;
+using Microsoft.Extensions.Configuration;
 using Standard.AI.OpenAI.Clients.OpenAIs;
 using Standard.AI.OpenAI.Models.Configurations;
 
@@ -14,12 +14,10 @@ namespace Standard.AI.OpenAI.Tests.Integration.APIs.ImageGenerations
 
         public ImageGenerationApiTests()
         {
-            var openAIConfigurations = new OpenAIConfigurations
-            {
-                ApiKey = Environment.GetEnvironmentVariable("ApiKey"),
-                OrganizationId = Environment.GetEnvironmentVariable("OrgId"),
-                ApiUrl = "https://api.openai.com/"
-            };
+            IConfiguration config = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+
+            OpenAIConfigurations openAIConfigurations = 
+                config.GetSection(key: "OpenAI").Get<OpenAIConfigurations>();
 
             this.openAIClient = new OpenAIClient(openAIConfigurations);
         }

--- a/Standard.AI.OpenAI.Tests.Integration/Standard.AI.OpenAI.Tests.Integration.csproj
+++ b/Standard.AI.OpenAI.Tests.Integration/Standard.AI.OpenAI.Tests.Integration.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
This aligns the use of the environment variables with out of the box [configuration builder usage](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#non-prefixed-environment-variables).

The GitHub pipeline variables need to be changed on approval.
The prefix I used is "OpenAI" therefore the environment variables need to be changed to:

- OpenAI__ApiKey
- OpenAI__ApiUrl
- OpenAI__OrganizationId

OpenAI__ApiKey is equivalent to appsettings OpenAI:ApiKey the ":" is replaced by **two underscores** "__"
The property names align with `OpenAIConfigurations` allowing the use of `IConfigurations` `.Get<>` method. 

Local Environment variables.
![image](https://github.com/hassanhabib/Standard.AI.OpenAI/assets/8317299/9dd9a1e3-2165-47e6-aea8-acfce1d01ca1)

Integration Test run locally
![image](https://github.com/hassanhabib/Standard.AI.OpenAI/assets/8317299/94ffb0cc-7a7d-4d9a-bd65-442965a5621f)
